### PR TITLE
With this changes you can change the default options in imap_fetchbody function

### DIFF
--- a/src/IMAP/Client.php
+++ b/src/IMAP/Client.php
@@ -265,11 +265,12 @@ class Client {
      *
      * @param Folder $folder
      * @param string $criteria
+     * @param integer $fetch_options
      *
      * @return array
      * @throws GetMessagesFailedException
      */
-    public function getMessages(Folder $folder, $criteria = 'ALL')
+    public function getMessages(Folder $folder, $criteria = 'ALL', $fetch_options = null)
     {
         $this->checkConnection();
 
@@ -281,7 +282,7 @@ class Client {
             if ($availableMessages !== false) {
                 $msglist = 1;
                 foreach ($availableMessages as $msgno) {
-                    $message = new Message($msgno, $msglist, $this);
+                    $message = new Message($msgno, $msglist, $this, $fetch_options);
 
                     $messages[$message->message_id] = $message;
                     $msglist++;

--- a/src/IMAP/Folder.php
+++ b/src/IMAP/Folder.php
@@ -143,8 +143,8 @@ class Folder {
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getMessages($criteria = 'ALL') {
-        return collect($this->client->getMessages($this, $criteria));
+    public function getMessages($criteria = 'ALL', $fetch_options = null) {
+        return collect($this->client->getMessages($this, $criteria, $fetch_options));
     }
 
     /**

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -314,7 +314,7 @@ class Message {
 
                 $encoding = $this->getEncoding($structure);
 
-                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_UID);
+                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_PEEK);
                 $content = $this->decodeString($content, $structure->encoding);
                 $content = $this->convertEncoding($content, $encoding);
 
@@ -331,7 +331,7 @@ class Message {
 
                 $encoding = $this->getEncoding($structure);
 
-                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_UID);
+                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_PEEK);
                 $content = $this->decodeString($content, $structure->encoding);
                 $content = $this->convertEncoding($content, $encoding);
 
@@ -374,7 +374,7 @@ class Message {
                     break;
             }
 
-            $content = imap_fetchbody($this->client->connection, $this->uid, ($partNumber) ? $partNumber : 1, FT_UID);
+            $content = imap_fetchbody($this->client->connection, $this->uid, ($partNumber) ? $partNumber : 1, FT_PEEK);
 
             $attachment = new \stdClass;
             $attachment->type = $type;

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -33,6 +33,13 @@ class Message {
     public $uid = '';
 
     /**
+     * Fetch body options
+     *
+     * @var string
+     */
+    public $fetch_options = null;
+
+    /**
      * @var int $msglist
      */
     public $msglist = 1;
@@ -118,11 +125,13 @@ class Message {
      * @param $uid
      * @param $msglist
      * @param \Webklex\IMAP\Client $client
+     * @param $fetch_options
      */
-    public function __construct($uid, $msglist, Client $client) {
+    public function __construct($uid, $msglist, Client $client, $fetch_options = null) {
         $this->uid = $uid;
         $this->msglist = $msglist;
         $this->client = $client;
+        $this->fetch_options = ($fetch_options) ? $fetch_options : FT_UID;
 
         $this->parseHeader();
         $this->parseBody();
@@ -314,7 +323,7 @@ class Message {
 
                 $encoding = $this->getEncoding($structure);
 
-                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_PEEK);
+                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, $this->fetch_options);
                 $content = $this->decodeString($content, $structure->encoding);
                 $content = $this->convertEncoding($content, $encoding);
 
@@ -331,7 +340,7 @@ class Message {
 
                 $encoding = $this->getEncoding($structure);
 
-                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, FT_PEEK);
+                $content = imap_fetchbody($this->client->connection, $this->uid, $partNumber, $this->fetch_options);
                 $content = $this->decodeString($content, $structure->encoding);
                 $content = $this->convertEncoding($content, $encoding);
 
@@ -374,7 +383,7 @@ class Message {
                     break;
             }
 
-            $content = imap_fetchbody($this->client->connection, $this->uid, ($partNumber) ? $partNumber : 1, FT_PEEK);
+            $content = imap_fetchbody($this->client->connection, $this->uid, ($partNumber) ? $partNumber : 1, $this->fetch_options);
 
             $attachment = new \stdClass;
             $attachment->type = $type;


### PR DESCRIPTION
This allow to change the fourth argument in the imap_fetchbody thats useful because you can use the FT_PEEK option that doesn't mark the messages as read when you fetch it.

For example:

`$oMailbox->getMessages('SINCE "2017-04-16"', FT_PEEK)`

