### PR TITLE
fixing issue text attachment overwrite mail body

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -314,7 +314,7 @@ class Message {
      * @param mixed $partNumber
      */
     private function fetchStructure($structure, $partNumber = null) {
-        if ($structure->type == self::TYPE_TEXT) {
+        if ($structure->type == self::TYPE_TEXT && $structure->ifdisposition == 0) {
             if ($structure->subtype == "PLAIN") {
                 if (!$partNumber) {
                     $partNumber = 1;


### PR DESCRIPTION
Case: When sending a mail with text file attachment, and mail body is also plain text, then the mail body gets overwritten by text file content.