### PR TITLE
Do not resolve uid to msgno if using FT_UID

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -129,7 +129,7 @@ class Message {
     public function __construct($uid, $msglist, Client $client, $fetch_options = null) {
         $this->msglist = $msglist;
         $this->client = $client;
-        $this->uid = imap_msgno($this->client->getConnection(), $uid);
+        $this->uid = ($fetch_options == FT_UID) ? $uid : imap_msgno($this->client->getConnection(), $uid);
 
         $this->setFetchOption($fetch_options);
         $this->parseHeader();


### PR DESCRIPTION
When utilizing the FT_UID fetch option, $this->uid was not properly set to appropriately account for the fetch options being utilized. Added check to confirm fetch options before setting $this->uid.