### PR TITLE
emails parsed without a content type of multipart present no body

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -313,7 +313,11 @@ class Message {
      * @param mixed $partNumber
      */
     private function fetchStructure($structure, $partNumber = null) {
-        if ($structure->type == self::TYPE_TEXT && $structure->ifdisposition == 0) {
+        if ($structure->type == self::TYPE_TEXT && 
+            ($structure->ifdisposition == 0 || 
+                ($structure->ifdisposition == 1 && !isset($structure->parts) && $partNumber == null)
+            )
+        ) {
             if ($structure->subtype == "PLAIN") {
                 if (!$partNumber) {
                     $partNumber = 1;


### PR DESCRIPTION
In cases where the content type of the email is not multipart, but instead an inline html or text content type, the message body is discarded and not presented via the API for processing and use. Most commonly presented with autoresponders from web clients such as gmail, but can also be seen in some cases with some mail clients. This patch will check if the processed structure is part of a multipart message to ensure html/text attachments aren't stripped from being an attachment during processing.

_Example header_

```
To: redacted
From: Ryan Gard <redacted>
Date: redacted
Message-ID: <redacted>
Subject: test vacation responder 
MIME-Version: 1.0
Content-Type: text/html; charset=UTF-8
Content-Transfer-Encoding: 7bit
Content-Disposition: inline
Precedence: bulk
X-Autoreply: yes
Auto-Submitted: auto-replied

<div dir="ltr">This is a test vacation responder</div><br/><br/>-- <br/>Ryan Gard<br/>
```