### PR TITLE
Fix assignment msgno to uid regardless of fetch_options is set in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [UNRELEASED]
 ### Fixed
-- NaN
+- Fix assignment ```msgno``` to ```uid``` regardless of ```fetch_options``` is set in config 
 
 ### Added
 - NaN
 
 ### Affected Classes
-- All
+- [Message::class](src/IMAP/Message.php)
 
 ## [1.0.3.6] - 2017-10-24
 ### Added

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -127,11 +127,12 @@ class Message {
      * @param $fetch_options
      */
     public function __construct($uid, $msglist, Client $client, $fetch_options = null) {
+        $this->setFetchOption($fetch_options);
+        
         $this->msglist = $msglist;
         $this->client = $client;
-        $this->uid = ($fetch_options == FT_UID) ? $uid : imap_msgno($this->client->getConnection(), $uid);
-
-        $this->setFetchOption($fetch_options);
+        $this->uid = ($this->fetch_options == FT_UID) ? $uid : imap_msgno($this->client->getConnection(), $uid);
+        
         $this->parseHeader();
         $this->parseBody();
     }

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -455,7 +455,6 @@ class Message {
      * @return $this
      */
     public function setFetchOption($option){
-        $option = (integer)$option;
         if(is_long($option) == true){
             $this->fetch_options = $option;
         }elseif(is_null($option) == true){


### PR DESCRIPTION
This pull request fixes wrong behaviour when call ```$client->getMessages($mailBox)``` returns the array of messages which have ```msgno``` in ```$message->uid``` property even the config option ```imap.options.fetch``` is set to ```FT_UID```.