### PR TITLE
Fix sender name in non-latin emails sent from Gmail

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -461,7 +461,12 @@ class Message {
                 $address->personal = false;
             }
 
-            $address->personal = imap_utf8($address->personal);
+            $personalParts = imap_mime_header_decode($address->personal);
+            
+            $address->personal = '';
+            foreach ($personalParts as $p) {
+                $address->personal .= $p->text;
+            }
 
             $address->mail = ($address->mailbox && $address->host) ? $address->mailbox.'@'.$address->host : false;
             $address->full = ($address->personal) ? $address->personal.' <'.$address->mail.'>' : $address->mail;

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -531,7 +531,21 @@ class Message {
 
                 $content = imap_fetchbody($this->client->getConnection(), $this->uid, $partNumber, $this->fetch_options | FT_UID);
                 $content = $this->decodeString($content, $structure->encoding);
-                $content = $this->convertEncoding($content, $encoding);
+
+                // We don't need to do convertEncoding() if charset is ASCII (us-ascii):
+                //     ASCII is a subset of UTF-8, so all ASCII files are already UTF-8 encoded
+                //     https://stackoverflow.com/a/11303410
+                // 
+                // us-ascii is the same as ASCII:
+                //     ASCII is the traditional name for the encoding system; the Internet Assigned Numbers Authority (IANA) 
+                //     prefers the updated name US-ASCII, which clarifies that this system was developed in the US and 
+                //     based on the typographical symbols predominantly in use there.
+                //     https://en.wikipedia.org/wiki/ASCII
+                //
+                // convertEncoding() function basically means convertToUtf8(), so when we convert ASCII string into UTF-8 it gets broken.
+                if ($encoding != 'us-ascii') {
+                    $content = $this->convertEncoding($content, $encoding);
+                }
 
                 $body = new \stdClass;
                 $body->type = "text";
@@ -550,7 +564,9 @@ class Message {
 
                 $content = imap_fetchbody($this->client->getConnection(), $this->uid, $partNumber, $this->fetch_options | FT_UID);
                 $content = $this->decodeString($content, $structure->encoding);
-                $content = $this->convertEncoding($content, $encoding);
+                if ($encoding != 'us-ascii') {
+                    $content = $this->convertEncoding($content, $encoding);
+                }
 
                 $body = new \stdClass;
                 $body->type = "html";


### PR DESCRIPTION
Fix for https://github.com/Webklex/laravel-imap/issues/154