### PR TITLE
Message Subject is wrong for Greek emails (UTF8)

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -288,7 +288,7 @@ class Message {
      * @throws Exceptions\ConnectionFailedException
      */
     private function parseHeader() {
-        $this->header = $header = imap_fetchheader($this->client->getConnection(), $this->uid, FT_UID);
+        $this->header = $header = imap_utf8(imap_fetchheader($this->client->getConnection(), $this->uid, FT_UID));
         if ($this->header) {
             $header = imap_rfc822_parse_headers($this->header);
         }
@@ -318,7 +318,7 @@ class Message {
         }
 
         if (property_exists($header, 'subject')) {
-            $this->subject = mb_decode_mimeheader($header->subject);
+            $this->subject = $header->subject;
         }
 
         if (property_exists($header, 'date')) {


### PR DESCRIPTION
Email subject was parsed like:
=?windows-1253?Q?Re:_(_Ticket:_BJBZF-W0NRO_)_(4JIV09081),_Order_placed_by?= =?windows-1253?B?INDBzcHDydnUx9MgysHU08nKz8PJwc3Nx9MsIHRvdGFsIDEyNyw1MCCA?=