### PR TITLE
Ignoring when both encodings are the same

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -850,6 +850,10 @@ class Message {
 
         $from = EncodingAliases::get($from);
         $to = EncodingAliases::get($to);
+        
+        if ($from === $to) {
+            return $str;
+        }
 
         // We don't need to do convertEncoding() if charset is ASCII (us-ascii):
         //     ASCII is a subset of UTF-8, so all ASCII files are already UTF-8 encoded


### PR DESCRIPTION
Ignoring the chatting when both encodings are the same

I have the same problem issue https://github.com/Webklex/laravel-imap/issues/203 and the problem is because the source and destination encoding are the same and do not need conversion. When this happens it is returned false instead of returning the text.