### PR TITLE
Handle attachment in multipart message (#226).

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -717,6 +717,10 @@ class Message {
                 $body->content = $content;
 
                 $this->bodies['html'] = $body;
+            } elseif ($structure->disposition == 'attachment') {
+                if ($this->getFetchAttachmentOption() === true) {
+                    $this->fetchAttachment($structure, $partNumber);
+                }
             }
         } elseif ($structure->type == IMAP::MESSAGE_TYPE_MULTIPART) {
             foreach ($structure->parts as $index => $subStruct) {


### PR DESCRIPTION
Fix for issue #226 . If the second part of an email message is an attachment it will now be added to the attachments collection in the message.