### PR TITLE
Replace helper functions for Laravel 6.0

### DIFF
--- a/src/IMAP/Attachment.php
+++ b/src/IMAP/Attachment.php
@@ -13,6 +13,7 @@
 namespace Webklex\IMAP;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Webklex\IMAP\Exceptions\MaskNotFoundException;
 use Webklex\IMAP\Exceptions\MethodNotFoundException;
@@ -111,7 +112,7 @@ class Attachment {
      */
     public function __call($method, $arguments) {
         if(strtolower(substr($method, 0, 3)) === 'get') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             if(isset($this->attributes[$name])) {
                 return $this->attributes[$name];
@@ -119,7 +120,7 @@ class Attachment {
 
             return null;
         }elseif (strtolower(substr($method, 0, 3)) === 'set') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             $this->attributes[$name] = array_pop($arguments);
 

--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -13,6 +13,7 @@
 namespace Webklex\IMAP;
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Webklex\IMAP\Exceptions\InvalidMessageDateException;
 use Webklex\IMAP\Exceptions\MaskNotFoundException;
 use Webklex\IMAP\Exceptions\MethodNotFoundException;
@@ -239,14 +240,14 @@ class Message {
      */
     public function __call($method, $arguments) {
         if(strtolower(substr($method, 0, 3)) === 'get') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             if(in_array($name, array_keys($this->attributes))) {
                 return $this->attributes[$name];
             }
 
         }elseif (strtolower(substr($method, 0, 3)) === 'set') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             if(in_array($name, array_keys($this->attributes))) {
                 $this->attributes[$name] = array_pop($arguments);

--- a/src/IMAP/Query/WhereQuery.php
+++ b/src/IMAP/Query/WhereQuery.php
@@ -12,6 +12,7 @@
 
 namespace Webklex\IMAP\Query;
 
+use Illuminate\Support\Str;
 use Webklex\IMAP\Exceptions\InvalidWhereQueryCriteriaException;
 use Webklex\IMAP\Exceptions\MethodNotFoundException;
 use Webklex\IMAP\Exceptions\MessageSearchValidationException;
@@ -73,7 +74,7 @@ class WhereQuery extends Query {
     public function __call($name, $arguments) {
         $that = $this;
 
-        $name = camel_case($name);
+        $name = Str::camel($name);
 
         if(strtolower(substr($name, 0, 3)) === 'not') {
             $that = $that->whereNot();

--- a/src/IMAP/Support/Masks/Mask.php
+++ b/src/IMAP/Support/Masks/Mask.php
@@ -12,6 +12,7 @@
 
 namespace Webklex\IMAP\Support\Masks;
 
+use Illuminate\Support\Str;
 use Webklex\IMAP\Exceptions\MethodNotFoundException;
 
 /**
@@ -60,14 +61,14 @@ class Mask {
      */
     public function __call($method, $arguments) {
         if(strtolower(substr($method, 0, 3)) === 'get') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             if(isset($this->attributes[$name])) {
                 return $this->attributes[$name];
             }
 
         }elseif (strtolower(substr($method, 0, 3)) === 'set') {
-            $name = snake_case(substr($method, 3));
+            $name = Str::snake(substr($method, 3));
 
             if(isset($this->attributes[$name])) {
                 $this->attributes[$name] = array_pop($arguments);


### PR DESCRIPTION
This pr aims at fixing the undefined function errors, these would throw because laravel deprecated and removed most of its helpers.

Fixes issues: #247  #244 