### PR TITLE
Use address charset from header information if set

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -608,7 +608,7 @@ class Message {
                 if(is_array($personalParts)) {
                     $address->personal = '';
                     foreach ($personalParts as $p) {
-                        $encoding = $this->getEncoding($p->text);
+                        $encoding = (property_exists($p, 'charset')) ? $p->charset : $this->getEncoding($p->text);
                         $address->personal .= $this->convertEncoding($p->text, $encoding);
                     }
                 }


### PR DESCRIPTION
This fixes charset conversion issues if the sender address in mail header isn't utf-8 encoded and a charset is explicit set.

This issue happens for example, if you send a mail from Microsoft Office (standard setup) with a Address containing characters like "äöü". 

The "To: " header looks something like the following in that case and isn't recognized by "getEncoding":
`To: =?iso-8859-1?B?J/b85Cc=?= <test@example.com>`