### PR TITLE
Fix 'where' in php 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ $aMessage = $oFolder->query()->not()->text('hello world')->get();
 
 //Get all messages by custom search criteria
 /** @var \Webklex\IMAP\Support\MessageCollection $aMessage */
-$aMessage = $oFolder->query()->where(["CUSTOM_FOOBAR" => "fooBar"]])->get();
+$aMessage = $oFolder->query()->where(["CUSTOM_FOOBAR" => "fooBar"])->get();
 
 ```
 
@@ -650,7 +650,6 @@ if you're just wishing a feature ;)
 | getMsglist      |                               | integer              | Get the current message list           |
 | getHeaderInfo   |                               | object               | Get the current header_info object     |
 | getHeader       |                               | string               | Get the current raw header             |
-| getMessageId    |                               | string               | Get the current message ID             |
 | getMessageNo    |                               | integer              | Get the current message number         |
 | getPriority     |                               | integer              | Get the current message priority       |
 | getSubject      |                               | string               | Get the current subject                |

--- a/src/IMAP/Query/WhereQuery.php
+++ b/src/IMAP/Query/WhereQuery.php
@@ -118,12 +118,11 @@ class WhereQuery extends Query {
      */
     public function where($criteria, $value = null) {
         if(is_array($criteria)){
-            foreach($criteria as $arguments){
-                if(count($arguments) == 1){
-                    $this->where($arguments[0]);
-                }elseif(count($arguments) == 2){
-                    $this->where($arguments[0], $arguments[1]);
+            foreach($criteria as $key => $value){
+                if(is_numeric($key)){
+                    return $this->where($value);
                 }
+                return $this->where($key, $value);
             }
         }else{
             $criteria = $this->validate_criteria($criteria);


### PR DESCRIPTION
- Exception message: "count(): Parameter must be an array or an object that implements Countable".
- Not found method "getMessageId"