### PR TITLE
Add a fallback when aliasing encodings for iconv

### DIFF
--- a/src/IMAP/EncodingAliases.php
+++ b/src/IMAP/EncodingAliases.php
@@ -465,17 +465,20 @@ class EncodingAliases {
     ];        
     
     /**
-     * Returns proper encoding mapping, if exsists. If it doesn't, return unchanged $encoding
+     * Returns proper encoding mapping, if it exists. If it doesn't, return $fallback if it is not null.
+     * If neither a mapping was found nor $fallback was given return the unchanged $encoding
      * 
      * @param string $encoding
      * @return string
      */
-    public static function get($encoding) {
+    public static function get($encoding, $fallback = null) {
         if (isset(self::$aliases[strtolower($encoding)])) {
             return self::$aliases[strtolower($encoding)];
-        } else {
-            return $encoding;
         }
+        if ($fallback !== null) {
+            return $fallback;
+        }
+        return $encoding;
     }
     
 }


### PR DESCRIPTION
I had the Problem that the 'charset' value in the 'from' value in the email header was invalid e.g. 'default'
If iconv gets an invalid charset as any one of its parameters an error will be thrown.
Since in this project the errors will be silently ignored the from header will just be set to be empty. 
https://github.com/Webklex/laravel-imap/blob/91f2bd6295a3619927f3f3200fa149b8483aeef1/src/IMAP/Message.php#L879

In order to prevent iconv getting passed an invalid charset, I extended the `get()` method in [EncodingAliases.php](https://github.com/Webklex/laravel-imap/blob/master/src/IMAP/EncodingAliases.php)  to return a fallback if the given encoding was not found in the alias array.
https://github.com/Webklex/laravel-imap/blob/91f2bd6295a3619927f3f3200fa149b8483aeef1/src/IMAP/EncodingAliases.php#L27-L465

The fallback is currently hardcoded to `'UTF-8'`.