### PR TITLE
Fix 'A non well formed numeric value encountered' ErrorException in Message.php

### DIFF
--- a/src/IMAP/Message.php
+++ b/src/IMAP/Message.php
@@ -690,7 +690,11 @@ class Message {
     private function fetchPart($structure, $partNumber){
         $encoding = $this->getEncoding($structure);
 
-        $content = \imap_fetchbody($this->client->getConnection(), $this->uid, $partNumber | 1, $this->fetch_options | IMAP::FT_UID);
+        if (!$partNumber) {
+            $partNumber = 1;
+        }
+
+        $content = \imap_fetchbody($this->client->getConnection(), $this->uid, $partNumber, $this->fetch_options | IMAP::FT_UID);
         $content = $this->decodeString($content, $structure->encoding);
 
         // We don't need to do convertEncoding() if charset is ASCII (us-ascii):


### PR DESCRIPTION
$partNumber is allowed to be a string, therefore '|' will lead to an Exception.

I have re implemented the old $partNumber check.


[imap-fetchbody()](https://www.php.net/manual/en/function.imap-fetchbody.php)