### PR TITLE
Honor explicit nulls in imap config during vendor merge

### DIFF
--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -65,6 +65,13 @@ class LaravelServiceProvider extends ServiceProvider {
 
         $vendor_config = require $path;
         $config = $this->app['config']->get($config_key, []);
+        if (is_array($config)) {
+            foreach ($config as $k => $v) {
+                if (array_key_exists($k, $vendor_config) && $v === null) {
+                    $vendor_config[$k] = null;
+                }
+            }
+        }
 
         $this->app['config']->set($config_key, $this->array_merge_recursive_distinct($vendor_config, $config));
 


### PR DESCRIPTION
### Summary
Treat explicit null values in the application config as overrides when merging the package (vendor) config into the application's `imap` config.

### Problem
When users set keys to `null` in their published `config/imap.php` (for example `'flags' => null` to accept all flags), the package's custom merge routine could either:
- ignore the `null` override and keep vendor defaults, or
- throw an "Undefined array key" exception during the merge.

This happens because the provider merges the vendor config and the app config with a custom `array_merge_recursive_distinct()` implementation which does not treat `null` as an explicit replacement and may attempt to operate on `null` values as if they were arrays.

### Cause
`LaravelServiceProvider::setVendorConfig()` uses the vendor config as the base and merges the application config into it using `array_merge_recursive_distinct($vendor_config, $config)`. If the application config contains keys explicitly set to `null`, the merge routine can mis-handle those values and produce invalid numeric keys or fail with undefined index errors.

### Change
Before performing the merge, detect keys in the application config that are explicitly set to `null` and set the corresponding keys in `$vendor_config` to `null`. This makes `null` an explicit override and prevents the merge routine from encountering invalid states.

Concretely:
- Iterate over the app config array.
- If a key exists in the vendor config and the app value is `=== null`, set `vendor_config[key] = null`.
- Proceed with the existing merge routine.

### Benefits
- Honors the documented/expected behavior: setting `'flags' => null` in `config/imap.php` will be respected (e.g. "accept all given flags").
- Prevents the "Undefined array key" exception seen when publishing the config and setting certain keys to `null`.
- Minimal and low-risk change that preserves current merge behavior for array values.

### Verification / Test steps
1. Publish or copy package config to `config/imap.php`.
2. Set `'flags' => null` in `config/imap.php`.
3. Clear config cache / restart PHP workers:
   - `php artisan config:clear`
   - restart php-fpm / queue workers / horizon (if applicable)
4. Boot the application and confirm:
   - `config('imap.flags')` returns `null`.
   - Fetching messages works; custom flags are accepted and no merge exception occurs.

### Compatibility & Risk
- Non-breaking: Existing users who supply arrays in their `imap` config are unaffected.
- Low risk: change only adjusts vendor config before the existing merge; it does not alter the core merge algorithm or other behavior.

### Follow-up
Consider hardening `array_merge_recursive_distinct()` in a later PR to generally handle non-array and null values more robustly across nested merges. This PR is intentionally minimal to fix the immediate incorrect behavior while remaining easy to review.
